### PR TITLE
WIP: Entity locator map

### DIFF
--- a/Svelto.ECS/EnginesRoot.Engines.cs
+++ b/Svelto.ECS/EnginesRoot.Engines.cs
@@ -50,9 +50,11 @@ namespace Svelto.ECS
                 new FasterDictionary<uint, FasterDictionary<RefWrapper<Type>, ITypeSafeDictionary>>();
             _groupsPerEntity    = new FasterDictionary<RefWrapper<Type>, FasterDictionary<uint, ITypeSafeDictionary>>();
             _groupedEntityToAdd = new DoubleBufferedEntitiesToAdd();
+            _entityLocatorMap = new FasterList<EntityLocatorMapElement>();
+            _egidToLocatorMap = new FasterDictionary<uint, FasterDictionary<uint, EntityLocator>>();
 
             _entitiesStream = new EntitiesStream();
-            _entitiesDB     = new EntitiesDB(_groupEntityComponentsDB, _groupsPerEntity, _entitiesStream);
+            _entitiesDB     = new EntitiesDB(_groupEntityComponentsDB, _groupsPerEntity, _entitiesStream, new EntityLocatorMap(this));
 
             scheduler        = entitiesComponentScheduler;
             scheduler.onTick = new EntitiesSubmitter(this);
@@ -88,7 +90,7 @@ namespace Svelto.ECS
                         Svelto.Console.LogException(e);
                     }
                 }
-                
+
                 foreach (FasterDictionary<uint, FasterDictionary<RefWrapper<Type>, ITypeSafeDictionary>>.
                     KeyValuePairFast groups in _groupEntityComponentsDB)
                 {
@@ -104,7 +106,7 @@ namespace Svelto.ECS
                             Svelto.Console.LogException(e);
                         }
                 }
-                
+
                 foreach (FasterDictionary<uint, FasterDictionary<RefWrapper<Type>, ITypeSafeDictionary>>.
                     KeyValuePairFast groups in _groupEntityComponentsDB)
                 {
@@ -129,7 +131,7 @@ namespace Svelto.ECS
 #endif
                 _groupedEntityToAdd.Dispose();
                 _entitiesStream.Dispose();
-                
+
                 scheduler.Dispose();
             }
 

--- a/Svelto.ECS/EnginesRoot.LocatorMap.cs
+++ b/Svelto.ECS/EnginesRoot.LocatorMap.cs
@@ -1,0 +1,200 @@
+﻿using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+using Svelto.DataStructures;
+
+namespace Svelto.ECS
+{
+    public partial class EnginesRoot
+    {
+        // The EntityLocatorMap provides a bidirectional map to help locate entities without using an EGID which might
+        // change in runtime. The Entity Locator map uses a reusable unique identifier struct called EntityLocator to
+        // find the last known EGID from last entity submission.
+        class EntityLocatorMap : IEntityLocatorMap
+        {
+            public EntityLocatorMap(EnginesRoot enginesRoot)
+            {
+                _enginesRoot = new WeakReference<EnginesRoot>(enginesRoot);
+            }
+
+            public EntityLocator GetLocator(EGID egid)
+            {
+                return _enginesRoot.Target.GetLocator(egid);
+            }
+
+            public EGID GetEGID(EntityLocator locator)
+            {
+                return _enginesRoot.Target.FindEGID(locator);
+            }
+
+            WeakReference<EnginesRoot> _enginesRoot;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void CreateLocator(EGID egid)
+        {
+            // Check if we need to create a new EntityLocator or whether we can recycle an existing one.s
+            EntityLocator locator;
+            if (_nextEntityId == _entityLocatorMap.count)
+            {
+                _entityLocatorMap.Add(new EntityLocatorMapElement(egid));
+                locator = new EntityLocator(_nextEntityId++);
+            }
+            else
+            {
+                ref var element = ref _entityLocatorMap[_nextEntityId];
+                locator = new EntityLocator(_nextEntityId, element.version);
+                // The recycle entities form a linked list, using the egid.entityID to store the next element.
+                _nextEntityId = element.egid.entityID;
+                element.egid = egid;
+            }
+
+            // When we create a new one there is nothing to recycle anymore, so we need to update the last recycle entityId.
+            if (_nextEntityId == _entityLocatorMap.count)
+            {
+                _lastEntityId = _entityLocatorMap.count;
+            }
+
+            // Update reverse map from egid to locator.
+            if (_egidToLocatorMap.TryGetValue(egid.groupID, out var groupMap) == false)
+            {
+                groupMap = new FasterDictionary<uint, EntityLocator>();
+                _egidToLocatorMap[egid.groupID] = groupMap;
+            }
+            groupMap[egid.entityID] = locator;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void UpdateLocator(EGID from, EGID to)
+        {
+            var locator = GetAndRemoveLocator(from);
+
+            _entityLocatorMap[locator.uniqueID].egid = to;
+
+            if (_egidToLocatorMap.TryGetValue(to.groupID, out var toGroupMap))
+            {
+                toGroupMap[to.entityID] = locator;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void RemoveLocator(EGID egid)
+        {
+            var locator = GetAndRemoveLocator(egid);
+
+            // Check if this is the first recycled element.
+            if (_lastEntityId == _entityLocatorMap.count)
+            {
+                _nextEntityId = locator.uniqueID;
+            }
+            // Otherwise add it as the last recycled element.
+            else
+            {
+                _entityLocatorMap[_lastEntityId].egid = new EGID(locator.uniqueID, 0);
+            }
+
+            // Invalidate the entity locator element by bumping its version and setting the egid to point to a unexisting element.
+            _entityLocatorMap[locator.uniqueID].egid = new EGID(_entityLocatorMap.count, 0);
+            _entityLocatorMap[locator.uniqueID].version++;
+
+            // Mark the element as the last element used.
+            _lastEntityId = locator.uniqueID;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void RemoveAllGroupLocators(uint groupId)
+        {
+            if (_egidToLocatorMap.TryGetValue(groupId, out var groupMap) == false)
+            {
+                return;
+            }
+
+            // We need to traverse all entities in the group and remove the locator using the egid.
+            // RemoveLocator would modify the enumerator so this is why we traverse the dictionary from last to first.
+            var keys = groupMap.unsafeKeys;
+            for (var i = groupMap.count - 1; true; i--)
+            {
+                RemoveLocator(new EGID(keys[i].key, groupId));
+                if (i == 0) break;
+            }
+
+            _egidToLocatorMap.Remove(groupId);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void UpdateAllGroupLocators(uint fromGroupId, uint toGroupId)
+        {
+            if (_egidToLocatorMap.TryGetValue(fromGroupId, out var groupMap) == false)
+            {
+                return;
+            }
+
+            // We need to traverse all entities in the group and update the locator using the egid.
+            // UpdateLocator would modify the enumerator so this is why we traverse the dictionary from last to first.
+            var keys = groupMap.unsafeKeys;
+            for (var i = groupMap.count - 1; true; i--)
+            {
+                UpdateLocator(new EGID(keys[i].key, fromGroupId), new EGID(keys[i].key, toGroupId));
+                if (i == 0) break;
+            }
+
+            _egidToLocatorMap.Remove(fromGroupId);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        EntityLocator GetLocator(EGID egid)
+        {
+            if (_egidToLocatorMap.TryGetValue(egid.groupID, out var groupMap))
+            {
+                if (groupMap.TryGetValue(egid.entityID, out var locator))
+                {
+                    return locator;
+                }
+            }
+
+            return EntityLocator.Invalid;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        EntityLocator GetAndRemoveLocator(EGID egid)
+        {
+            if (_egidToLocatorMap.TryGetValue(egid.groupID, out var groupMap))
+            {
+                if (groupMap.TryGetValue(egid.entityID, out var locator))
+                {
+                    groupMap.Remove(egid.entityID);
+                    return locator;
+                }
+            }
+
+            return EntityLocator.Invalid;
+        }
+
+        EGID FindEGID(EntityLocator locator)
+        {
+#if DEBUG && !PROFILE_SVELTO
+            if (locator.uniqueID >= _entityLocatorMap.count)
+            {
+                throw new ECSException("EntityLocator is out of bounds.");
+            }
+#endif
+            // Make sure we are querying for the current version of the locator.
+            // Otherwise the locator is pointing to a removed entity.
+            if (_entityLocatorMap[locator.uniqueID].version == locator.version)
+            {
+                return _entityLocatorMap[locator.uniqueID].egid;
+            }
+            else
+            {
+#if DEBUG && !PROFILE_SVELTO
+                throw new ECSException("Attempting to find EGID with outdated entityLocator");
+#endif
+                return new EGID();
+            }
+        }
+
+        uint _nextEntityId;
+        uint _lastEntityId;
+        readonly FasterList<EntityLocatorMapElement> _entityLocatorMap;
+        readonly FasterDictionary<uint, FasterDictionary<uint, EntityLocator>> _egidToLocatorMap;
+    }
+}

--- a/Svelto.ECS/EnginesRoot.LocatorMap.cs
+++ b/Svelto.ECS/EnginesRoot.LocatorMap.cs
@@ -21,9 +21,9 @@ namespace Svelto.ECS
                 return _enginesRoot.Target.GetLocator(egid);
             }
 
-            public EGID GetEGID(EntityLocator locator)
+            public bool TryGetEGID(EntityLocator locator, out EGID egid)
             {
-                return _enginesRoot.Target.FindEGID(locator);
+                return _enginesRoot.Target.TryGetEGID(locator, out egid);
             }
 
             WeakReference<EnginesRoot> _enginesRoot;
@@ -190,26 +190,20 @@ namespace Svelto.ECS
             return EntityLocator.Invalid;
         }
 
-        EGID FindEGID(EntityLocator locator)
+        bool TryGetEGID(EntityLocator locator, out EGID egid)
         {
-#if DEBUG && !PROFILE_SVELTO
-            if (locator.uniqueID >= _entityLocatorMap.count)
-            {
-                throw new ECSException("EntityLocator is out of bounds.");
-            }
-#endif
+            egid = new EGID();
+            if (locator == EntityLocator.Invalid) return false;
             // Make sure we are querying for the current version of the locator.
             // Otherwise the locator is pointing to a removed entity.
             if (_entityLocatorMap[locator.uniqueID].version == locator.version)
             {
-                return _entityLocatorMap[locator.uniqueID].egid;
+                egid = _entityLocatorMap[locator.uniqueID].egid;
+                return true;
             }
             else
             {
-#if DEBUG && !PROFILE_SVELTO
-                throw new ECSException("Attempting to find EGID with outdated entityLocator");
-#endif
-                return new EGID();
+                return false;
             }
         }
 

--- a/Svelto.ECS/EntitiesDB.cs
+++ b/Svelto.ECS/EntitiesDB.cs
@@ -339,6 +339,6 @@ namespace Svelto.ECS
         //may change in future as it could be expanded to support queries
         readonly FasterDictionary<RefWrapper<Type>, FasterDictionary<uint, ITypeSafeDictionary>> _groupsPerEntity;
 
-        IEntityLocatorMap _entityLocatorMap;
+        readonly IEntityLocatorMap _entityLocatorMap;
     }
 }

--- a/Svelto.ECS/EntitiesDB.cs
+++ b/Svelto.ECS/EntitiesDB.cs
@@ -26,9 +26,9 @@ namespace Svelto.ECS
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EGID GetEGID(EntityLocator entityLocator)
+        public bool FindEGID(EntityLocator entityLocator, out EGID egid)
         {
-            return _entityLocatorMap.GetEGID(entityLocator);
+            return _entityLocatorMap.TryGetEGID(entityLocator, out egid);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Svelto.ECS/EntityLocator.cs
+++ b/Svelto.ECS/EntityLocator.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 660,661
+
+namespace Svelto.ECS
+{
+    [Serialization.DoNotSerialize]
+    [Serializable]
+    [StructLayout(LayoutKind.Explicit)]
+    public struct EntityLocator : IEquatable<EntityLocator>
+    {
+        [FieldOffset(0)] public readonly uint uniqueID;
+        [FieldOffset(4)] public readonly uint version;
+        [FieldOffset(0)] readonly ulong _GID;
+
+        public static bool operator ==(EntityLocator obj1, EntityLocator obj2)
+        {
+            return obj1._GID == obj2._GID;
+        }
+
+        public static bool operator !=(EntityLocator obj1, EntityLocator obj2)
+        {
+            return obj1._GID != obj2._GID;
+        }
+
+        public EntityLocator(uint uniqueId) : this(uniqueId, 0) {}
+
+        public EntityLocator(uint uniqueId, uint version) : this()
+        {
+            _GID = MAKE_GLOBAL_ID(uniqueId, version);
+        }
+
+        static ulong MAKE_GLOBAL_ID(uint uniqueId, uint version)
+        {
+            return (ulong)version << 32 | ((ulong)uniqueId & 0xFFFFFFFF);
+        }
+
+        public static EntityLocator Invalid => new EntityLocator(uint.MaxValue, uint.MaxValue);
+
+        public bool Equals(EntityLocator other)
+        {
+            return _GID == other._GID;
+        }
+
+        public bool Equals(EntityLocator x, EntityLocator y)
+        {
+            return x == y;
+        }
+
+        public override string ToString()
+        {
+            return "id:".FastConcat(uniqueID).FastConcat(" version:").FastConcat(version);
+        }
+    }
+}

--- a/Svelto.ECS/EntityLocatorMapElement.cs
+++ b/Svelto.ECS/EntityLocatorMapElement.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Svelto.ECS
+{
+    internal struct EntityLocatorMapElement
+    {
+        internal EGID egid;
+        internal uint version;
+
+        internal EntityLocatorMapElement(EGID egid)
+        {
+            this.egid = egid;
+            version = 0;
+        }
+    }
+}

--- a/Svelto.ECS/IEntityLocatorMap.cs
+++ b/Svelto.ECS/IEntityLocatorMap.cs
@@ -1,0 +1,9 @@
+﻿namespace Svelto.ECS
+{
+    public interface IEntityLocatorMap
+    {
+        EntityLocator GetLocator(EGID egid);
+
+        EGID GetEGID(EntityLocator locator);
+    }
+}

--- a/Svelto.ECS/IEntityLocatorMap.cs
+++ b/Svelto.ECS/IEntityLocatorMap.cs
@@ -4,6 +4,6 @@
     {
         EntityLocator GetLocator(EGID egid);
 
-        EGID GetEGID(EntityLocator locator);
+        bool TryGetEGID(EntityLocator locator, out EGID egid);
     }
 }


### PR DESCRIPTION
Well this is my first approach to it. I decided to name it EntityLocator and EntityLocatorMap to avoid confusions between EUID and EGID.

I also realized I needed the map to be bidirectional in order to allow me to update it on entity submissions so once I already had this I figured having a similar interface as INeedEGID would be harder for me to implement than just allowing the entityDB to search from EGID to EntityLocator. So I decided to make the API in entitiesDB be: `EntityLocator entitiesDB.GetLocator(EGID)` and `EGID entitiesDB.GetEGID(EntityLocator)`. 

I have tests for this ready to be pushed, but we can merge them after we have finalize this feature.
We can discuss it over the week, I have a few questions about how I implemented a few things.