### PR TITLE
Added Extensions for Godot 3.x LTS / 4

### DIFF
--- a/com.sebaslab.svelto.ecs/Extensions/Godot/GodotEntitySubmissionScheduler.cs
+++ b/com.sebaslab.svelto.ecs/Extensions/Godot/GodotEntitySubmissionScheduler.cs
@@ -1,0 +1,59 @@
+﻿#if GODOT
+using System;
+using Godot;
+
+namespace Svelto.ECS.Schedulers.Godot
+{
+    //The EntitySubmissionScheduler has been introduced to make the entity components submission logic platform independent
+    //You can customize the scheduler if you wish
+    public class GodotEntitySubmissionScheduler : EntitiesSubmissionScheduler
+    {
+        readonly GodotScheduler        _scheduler;
+        EnginesRoot.EntitiesSubmitter _onTick;
+
+        /// <summary>
+        /// Unlike unity. Creating a gameObject with new GameObject(name) will not add it to the current scene
+        /// It needs to be added as a child to the scene (which is also a ~~gameObject~~Node)
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="parent"></param>
+        public GodotEntitySubmissionScheduler(string name, Node parent)
+        {
+            
+            _scheduler = new GodotScheduler();
+            _scheduler.onTick = SubmitEntities;
+            parent.AddChild(_scheduler);
+        }
+
+        private void SubmitEntities()
+        {
+            try
+            {
+                _onTick.SubmitEntities();
+            }
+            catch (Exception e)
+            {
+                paused = true;
+                
+                Svelto.Console.LogException(e);
+
+                throw;
+            }
+        }
+
+        protected internal override EnginesRoot.EntitiesSubmitter onTick
+        {
+            set => _onTick = value;
+        }
+
+        public override void Dispose()
+        {
+            if (_scheduler != null)
+            {
+                _scheduler.QueueFree();
+            }
+        }
+    }
+
+}
+#endif

--- a/com.sebaslab.svelto.ecs/Extensions/Godot/GodotScheduler.cs
+++ b/com.sebaslab.svelto.ecs/Extensions/Godot/GodotScheduler.cs
@@ -1,0 +1,30 @@
+﻿#if GODOT
+using Godot;
+
+namespace Svelto.ECS.Schedulers.Godot
+{
+    /// <summary>
+    /// Unlike Unity, in godot Everything is a Node. Monobehaviour = Node, GameObject = Node etc.
+    /// </summary>
+    public partial class GodotScheduler : Node
+    {   
+        internal System.Action onTick;
+
+        public override void _Process(double delta)
+        {
+           Routine();
+        }
+
+        public async void Routine()
+        {
+            while (true)
+            {
+                await ToSignal(GetTree(), "process_frame");
+        
+                onTick();
+                
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Added minimal Extensions classes to start working in godot:

- Added a GodotScheduler extension (equivalent to MonoScheduler)
- Added a Godot specific EntitySubmissionScheduler (equivalent to UnityEntitySubmissionScheduler)

Note: (optional) Godot specific Context is in this PR in Svelto.Commoin: https://github.com/sebas77/Svelto.Common/pull/20

all godot specific classes are in an #if GODOT preprocessor